### PR TITLE
Fix dialog dismiss when tapping on backdrop overlay

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -190,9 +190,9 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
     },
 
     _onIronOverlayOpened: function() {
+      this.backdropElement.addEventListener('click', this._boundOnBackdropClick);
       if (this.modal) {
         document.body.addEventListener('focus', this._boundOnFocus, true);
-        this.backdropElement.addEventListener('click', this._boundOnBackdropClick);
       }
     },
 
@@ -228,6 +228,8 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
         } else {
           this._focusNode.focus();
         }
+      } else if (!this.noCancelOnOutsideClick) {
+        this.close();
       }
     }
 


### PR DESCRIPTION
a tap on the background overlay does not dismiss the dialog on safari mobile. This fixes it.