### PR TITLE
fix dropdown-inside-dialog overflow

### DIFF
--- a/paper-dialog-common.css
+++ b/paper-dialog-common.css
@@ -11,11 +11,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host {
   display: block;
   margin: 24px 40px;
+  -webkit-overflow-scrolling: touch;
 
   background: var(--paper-dialog-background-color, --primary-background-color);
   color: var(--paper-dialog-color, --primary-text-color);
 
-  @apply(--layout-scroll);
   @apply(--paper-font-body1);
   @apply(--shadow-elevation-16dp);
   @apply(--paper-dialog);


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog/issues/37, https://github.com/PolymerElements/paper-dropdown-menu/issues/43 (they're basically the same issue)

The only thing we were picking up from `layout-scroll` was the overflow and the touch, so I kept the touch. I've tested this with `paper-dialog` and `paper-dialog-scrollable` and it looks like a no-op.
