### PR TITLE
avoid applying focus if dialog is not currentOverlay

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-styles/demo-pages.html">
   <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../../paper-dialog-scrollable/paper-dialog-scrollable.html">
-  
+
   <style is="custom-style">
     .centered {
       text-align: center;
@@ -48,9 +48,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <h2>Alert</h2>
       <p>Discard draft?</p>
       <div class="buttons">
+        <paper-button data-dialog="multiple">More details</paper-button>
         <paper-button dialog-dismiss>Cancel</paper-button>
         <paper-button dialog-confirm autofocus>Discard</paper-button>
       </div>
+    </simple-dialog>
+
+    <simple-dialog id="multiple" modal>
+      <h2>Details</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <paper-button dialog-confirm autofocus>OK</paper-button>
     </simple-dialog>
 
     <button data-dialog="scrolling">scrolling</button>

--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -205,7 +205,7 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
     },
 
     _onFocus: function(event) {
-      if (this.modal) {
+      if (this.modal && this._manager.currentOverlay() === this) {
         var target = event.target;
         while (target && target !== this && target !== document.body) {
           target = target.parentNode;
@@ -225,7 +225,7 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
     },
 
     _onBackdropClick: function() {
-      if (this.modal) {
+      if (this.modal && this._manager.currentOverlay() === this) {
         if (this._lastFocusedElement) {
           this._lastFocusedElement.focus();
         } else {

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -89,6 +89,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="multiple">
+      <template>
+        <test-dialog modal id="dialog1">
+          <p>Dialog 1</p>
+        </test-dialog>
+        <test-dialog modal id="dialog2">
+          <p>Dialog 2</p>
+        </test-dialog>
+      </template>
+    </test-fixture>
+
     <script>
 
       function runAfterOpen(dialog, cb) {
@@ -175,6 +186,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             });
             button.click();
+          });
+        });
+
+        test('multiple modal dialogs opened, handle focus change', function(done) {
+          var dialogs = fixture('multiple');
+          var focusChange = sinon.stub();
+          document.body.addEventListener('focus', focusChange, true);
+
+          runAfterOpen(dialogs[0], function() {
+            // Wait 10ms to allow focus changes
+            dialogs[1].async(dialogs[1].open, 10);
+            dialogs[1].addEventListener('iron-overlay-opened', function() {
+              // Wait 10ms to allow focus changes
+              setTimeout(function() {
+                // Should not enter in an infinite loop.
+                assert.equal(focusChange.callCount, 2, 'focus change count');
+                done();
+              }, 10);
+            });
+          });
+        });
+
+        test('multiple modal dialogs opened, handle backdrop click', function(done) {
+          var dialogs = fixture('multiple');
+          var focusChange = sinon.stub();
+          document.body.addEventListener('focus', focusChange, true);
+
+          runAfterOpen(dialogs[0], function() {
+            // Wait 10ms to allow focus changes
+            dialogs[1].async(dialogs[1].open, 10);
+            dialogs[1].addEventListener('iron-overlay-opened', function() {
+              // This will trigger backdropElement.click listener for both dialogs.
+              dialogs[1].backdropElement.click();
+              // Wait 10ms to allow focus changes
+              setTimeout(function() {
+                // Should not enter in an infinite loop.
+                assert.equal(focusChange.callCount, 2, 'focus change count');
+                done();
+              }, 10);
+            });
           });
         });
 


### PR DESCRIPTION
Fixes #46 by checking if the dialog is the currentOverlay before applying focus.