### PR TITLE
set noCancelOnEscKey when modal changes

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -77,10 +77,9 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
     properties: {
 
       /**
-       * If `modal` is true, this implies `no-cancel-on-outside-click` and `with-backdrop`.
+       * If `modal` is true, this implies `no-cancel-on-outside-click`, `no-cancel-on-esc-key` and `with-backdrop`.
        */
       modal: {
-        observer: '_modalChanged',
         type: Boolean,
         value: false
       },
@@ -106,10 +105,21 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
 
     },
 
+    observers: [
+      '_modalChanged(modal, _readied)'
+    ],
+
     listeners: {
       'tap': '_onDialogClick',
       'iron-overlay-opened': '_onIronOverlayOpened',
       'iron-overlay-closed': '_onIronOverlayClosed'
+    },
+
+    ready: function () {
+      // Only now these properties can be read.
+      this.__prevNoCancelOnOutsideClick = this.noCancelOnOutsideClick;
+      this.__prevNoCancelOnEscKey = this.noCancelOnEscKey;
+      this.__prevWithBackdrop = this.withBackdrop;
     },
 
     attached: function() {
@@ -122,17 +132,40 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
       Polymer.dom(this).unobserveNodes(this._ariaObserver);
     },
 
-    _modalChanged: function() {
-      if (this.modal) {
+    _modalChanged: function(modal, readied) {
+      if (modal) {
         this.setAttribute('aria-modal', 'true');
       } else {
         this.setAttribute('aria-modal', 'false');
       }
-      // modal implies noCancelOnOutsideClick and withBackdrop if true, don't overwrite
-      // those properties otherwise.
-      if (this.modal) {
+
+      // modal implies noCancelOnOutsideClick, noCancelOnEscKey and withBackdrop.
+      // We need to wait for the element to be ready before we can read the
+      // properties values.
+      if (!readied) {
+        return;
+      }
+
+      if (modal) {
+        this.__prevNoCancelOnOutsideClick = this.noCancelOnOutsideClick;
+        this.__prevNoCancelOnEscKey = this.noCancelOnEscKey;
+        this.__prevWithBackdrop = this.withBackdrop;
         this.noCancelOnOutsideClick = true;
+        this.noCancelOnEscKey = true;
         this.withBackdrop = true;
+      } else {
+        // If the value was changed to false, let it false.
+        this.noCancelOnOutsideClick = this.noCancelOnOutsideClick &&
+          this.__prevNoCancelOnOutsideClick;
+        this.noCancelOnEscKey = this.noCancelOnEscKey &&
+          this.__prevNoCancelOnEscKey;
+        this.withBackdrop = this.withBackdrop && this.__prevWithBackdrop;
+      }
+
+      if (this.opened) {
+        // Reset focus and click listeners.
+        this._onIronOverlayClosed();
+        this._onIronOverlayOpened();
       }
     },
 

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -9,6 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
   <head>
 
     <title>paper-dialog-behavior tests</title>
@@ -27,6 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="test-buttons.html">
 
   </head>
+
   <body>
 
     <test-fixture id="basic">
@@ -63,14 +65,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <test-fixture id="backdrop">
+    <test-fixture id="like-modal">
       <template>
-        <test-dialog with-backdrop>
+        <test-dialog no-cancel-on-esc-key no-cancel-on-outside-click with-backdrop>
           <p>Dialog</p>
-          <div class="buttons">
-            <button dialog-dismiss>dismiss</button>
-            <button dialog-confirm autofocus>confirm</button>
-          </div>
         </test-dialog>
       </template>
     </test-fixture>
@@ -132,6 +130,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
 
+      // Firefox 43 and later will keep the focus on the search bar, so we need
+      // to move the focus on the document for focus-related tests.
+      function ensureDocumentHasFocus() {
+        window.top && window.top.focus();
+      }
+
       function runAfterOpen(dialog, cb) {
         dialog.addEventListener('iron-overlay-opened', function() {
           cb();
@@ -175,10 +179,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             });
             Polymer.dom(dialog).querySelector('test-buttons').$.dismiss.click();
-            // We don't wait too long to fail.
-            setTimeout(function didNotClose() {
-              done(new Error('dialog-dismiss click did not close overlay'));
-            }, 20);
           });
         });
 
@@ -203,10 +203,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             });
             Polymer.dom(dialog).querySelector('test-buttons').$.confirm.click();
-            // We don't wait too long to fail.
-            setTimeout(function didNotClose() {
-              done(new Error('dialog-confirm click did not close overlay'));
-            }, 20);
           });
         });
 
@@ -232,14 +228,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }, 10);
         });
 
-        test('modal dialog has backdrop', function() {
-          var dialog = fixture('modal');
-          assert.isTrue(dialog.withBackdrop, 'withBackdrop is true');
-        });
+        var properties = ['noCancelOnEscKey', 'noCancelOnOutsideClick', 'withBackdrop'];
+        properties.forEach(function(property) {
 
-        test('modal dialog has no-cancel-on-outside-click', function() {
-          var dialog = fixture('modal');
-          assert.isTrue(dialog.noCancelOnOutsideClick, 'noCancelOnOutsideClick is true');
+          test('modal sets ' + property + ' to true', function() {
+            var dialog = fixture('modal');
+            assert.isTrue(dialog[property], property);
+          });
+
+          test('modal toggling keeps current value of ' + property, function() {
+            var dialog = fixture('modal');
+            // Changed to false while modal is true.
+            dialog[property] = false;
+            dialog.modal = false;
+            assert.isFalse(dialog[property], property + ' is false');
+          });
+
+          test('modal toggling keeps previous value of ' + property, function() {
+            var dialog = fixture('basic');
+            // Changed before modal is true.
+            dialog[property] = true;
+            // Toggle twice to trigger observer.
+            dialog.modal = true;
+            dialog.modal = false;
+            assert.isTrue(dialog[property], property + ' is still true');
+          });
+
+          test('default modal does not override ' + property +' (attribute)', function() {
+            // Property is set on ready from attribute.
+            var dialog = fixture('like-modal');
+            assert.isTrue(dialog[property], property + ' is true');
+          });
+
+          test('modal toggling keeps previous value of ' + property + ' (attribute)', function() {
+            // Property is set on ready from attribute.
+            var dialog = fixture('like-modal');
+            // Toggle twice to trigger observer.
+            dialog.modal = true;
+            dialog.modal = false;
+            assert.isTrue(dialog[property], property + ' is still true');
+          });
+
         });
 
         test('clicking outside a modal dialog does not move focus from dialog', function(done) {
@@ -267,6 +296,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('multiple modal dialogs opened, handle focus change', function(done) {
+          ensureDocumentHasFocus();
+
           var dialogs = fixture('multiple');
           var focusChange = sinon.stub();
           document.body.addEventListener('focus', focusChange, true);
@@ -286,6 +317,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('multiple modal dialogs opened, handle backdrop click', function(done) {
+          ensureDocumentHasFocus();
+
           var dialogs = fixture('multiple');
           var focusChange = sinon.stub();
           document.body.addEventListener('focus', focusChange, true);
@@ -382,8 +415,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
       });
-
     </script>
 
   </body>
+
 </html>


### PR DESCRIPTION
Fixes #18, Fixes #64.
Sets `noCancelOnEscKey = noCancelOnOutsideClick = withBackdrop = true` when `modal = true` and restores their old values when `modal = false`