### PR TITLE
stop propagation of event to avoid other dialogs to be closed

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -181,10 +181,12 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
           if (target.hasAttribute('dialog-dismiss')) {
             this._updateClosingReasonConfirmed(false);
             this.close();
+            event.stopPropagation();
             break;
           } else if (target.hasAttribute('dialog-confirm')) {
             this._updateClosingReasonConfirmed(true);
             this.close();
+            event.stopPropagation();
             break;
           }
         }

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -110,6 +110,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="nestedmodals">
+      <template>
+        <test-dialog modal opened>
+          <p>Dialog 1</p>
+          <div class="buttons">
+            <button dialog-dismiss>dismiss</button>
+            <button dialog-confirm autofocus>confirm</button>
+          </div>
+
+          <test-dialog modal opened>
+            <p>Dialog 2</p>
+            <div class="buttons">
+              <button dialog-dismiss>dismiss</button>
+              <button dialog-confirm autofocus>confirm</button>
+            </div>
+          </test-dialog>
+        </test-dialog>
+      </template>
+    </test-fixture>
+
     <script>
 
       function runAfterOpen(dialog, cb) {
@@ -188,6 +208,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done(new Error('dialog-confirm click did not close overlay'));
             }, 20);
           });
+        });
+
+        test('clicking dialog-dismiss button closes only the dialog where is contained', function(done) {
+          var dialog = fixture('nestedmodals');
+          var innerDialog = Polymer.dom(dialog).querySelector('test-dialog');
+          Polymer.dom(innerDialog).querySelector('[dialog-dismiss]').click();
+          setTimeout(function() {
+            assert.isFalse(innerDialog.opened, 'inner dialog is closed');
+            assert.isTrue(dialog.opened, 'dialog is still open');
+            done();
+          }, 10);
+        });
+
+        test('clicking dialog-confirm button closes only the dialog where is contained', function(done) {
+          var dialog = fixture('nestedmodals');
+          var innerDialog = Polymer.dom(dialog).querySelector('test-dialog');
+          Polymer.dom(innerDialog).querySelector('[dialog-confirm]').click();
+          setTimeout(function() {
+            assert.isFalse(innerDialog.opened, 'inner dialog is closed');
+            assert.isTrue(dialog.opened, 'dialog is still open');
+            done();
+          }, 10);
         });
 
         test('with-backdrop works', function() {


### PR DESCRIPTION
Fixes #31 by stopping the event propagation to other dialogs. Only the deepest modal dialog will have its listener triggered.