### PR TITLE
[WIP] reset -webkit-overflow-scrolling while the modal is opened

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -196,12 +196,33 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
       if (this.modal) {
         document.body.addEventListener('focus', this._boundOnFocus, true);
         this.backdropElement.addEventListener('click', this._boundOnBackdropClick);
+        this._setParentsScrolling();
       }
     },
 
     _onIronOverlayClosed: function() {
       document.body.removeEventListener('focus', this._boundOnFocus, true);
       this.backdropElement.removeEventListener('click', this._boundOnBackdropClick);
+      this._setParentsScrolling();
+    },
+
+    _setParentsScrolling: function() {
+      // Fixes scrolling issues caused by '-webkit-overflow-scrolling' on mobile safari.
+      if ('-webkit-overflow-scrolling' in this.style) {
+        var parent = Polymer.dom(this).parentNode;
+        while (parent) {
+          if (this.opened) {
+            // Store the old value of '-webkit-overflow-scrolling'.
+            parent._oldWebkitOverflowScrolling = parent.style['-webkit-overflow-scrolling'];
+            parent.style['-webkit-overflow-scrolling'] = 'auto';
+          } else if ('_oldWebkitOverflowScrolling' in parent) {
+            // Restore the old value of '-webkit-overflow-scrolling'.
+            parent.style['-webkit-overflow-scrolling'] = parent._oldWebkitOverflowScrolling;
+            delete parent._oldWebkitOverflowScrolling;
+          }
+          parent = Polymer.dom(parent).parentNode;
+        }
+      }
     },
 
     _onFocus: function(event) {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog/issues/79 by resetting `-webkit-overflow-scrolling` to `auto` when the dialog is opened.