### PR TITLE
remove references to backdropElement

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -113,25 +113,13 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
     },
 
     attached: function() {
-      this._observer = this._observe(this);
+      // this._observer is used by iron-overlay-behavior
+      this._ariaObserver = Polymer.dom(this).observeNodes(this._updateAriaLabelledBy);
       this._updateAriaLabelledBy();
     },
 
     detached: function() {
-      if (this._observer) {
-        this._observer.disconnect();
-      }
-    },
-
-    _observe: function(node) {
-      var observer = new MutationObserver(function() {
-        this._updateAriaLabelledBy();
-      }.bind(this));
-      observer.observe(node, {
-        childList: true,
-        subtree: true
-      });
-      return observer;
+      Polymer.dom(this).unobserveNodes(this._ariaObserver);
     },
 
     _modalChanged: function() {
@@ -197,38 +185,30 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
     _onIronOverlayOpened: function() {
       if (this.modal) {
         document.body.addEventListener('focus', this._boundOnFocus, true);
-        this.backdropElement.addEventListener('click', this._boundOnBackdropClick);
+        document.body.addEventListener('click', this._boundOnBackdropClick, true);
       }
     },
 
     _onIronOverlayClosed: function() {
       this._lastFocusedElement = null;
       document.body.removeEventListener('focus', this._boundOnFocus, true);
-      this.backdropElement.removeEventListener('click', this._boundOnBackdropClick);
+      document.body.removeEventListener('click', this._boundOnBackdropClick, true);
     },
 
     _onFocus: function(event) {
       if (this.modal && this._manager.currentOverlay() === this) {
-        var target = event.target;
-        while (target && target !== this && target !== document.body) {
-          target = target.parentNode;
-        }
-        if (target) {
-          if (target === document.body) {
-            if (this._lastFocusedElement) {
-              this._lastFocusedElement.focus();
-            } else {
-              this._focusNode.focus();
-            }
-          } else {
-            this._lastFocusedElement = event.target;
-          }
+        if (Polymer.dom(event).path.indexOf(this) !== -1) {
+          this._lastFocusedElement = event.target;
+        } else if (this._lastFocusedElement) {
+          this._lastFocusedElement.focus();
+        } else {
+          this._focusNode.focus();
         }
       }
     },
 
-    _onBackdropClick: function() {
-      if (this.modal && this._manager.currentOverlay() === this) {
+    _onBackdropClick: function(event) {
+      if (this.modal && this._manager.currentOverlay() === this && Polymer.dom(event).path.indexOf(this) === -1) {
         if (this._lastFocusedElement) {
           this._lastFocusedElement.focus();
         } else {

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -232,13 +232,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }, 10);
         });
 
-        test('with-backdrop works', function() {
-          var dialog = fixture('backdrop');
-          runAfterOpen(dialog, function() {
-            assert.isTrue(dialog.backdropElement.opened, 'backdrop is open');
-          });
-        });
-
         test('modal dialog has backdrop', function() {
           var dialog = fixture('modal');
           assert.isTrue(dialog.withBackdrop, 'withBackdrop is true');
@@ -252,7 +245,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('clicking outside a modal dialog does not move focus from dialog', function(done) {
           var dialog = fixture('modal');
           runAfterOpen(dialog, function() {
-            dialog.backdropElement.click();
+            document.body.click();
             setTimeout(function() {
               assert.equal(document.activeElement, Polymer.dom(dialog).querySelector('[autofocus]'), 'document.activeElement is the autofocused button');
               done();
@@ -301,8 +294,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // Wait 10ms to allow focus changes
             dialogs[1].async(dialogs[1].open, 10);
             dialogs[1].addEventListener('iron-overlay-opened', function() {
-              // This will trigger backdropElement.click listener for both dialogs.
-              dialogs[1].backdropElement.click();
+              // This will trigger click listener for both dialogs.
+              document.body.click();
               // Wait 10ms to allow focus changes
               setTimeout(function() {
                 // Should not enter in an infinite loop.
@@ -335,7 +328,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
 
           function onSecondOpen() {
-            dialog.backdropElement.click();
+            document.body.click();
             setTimeout(function() {
               assert.equal(document.activeElement, Polymer.dom(dialog).querySelector('[autofocus]'), 'document.activeElement is the autofocused button');
               done();


### PR DESCRIPTION
Add click listener to `document.body` instead of `backdropElement`.
Avoid overriding `this._observer` since it is defined by `iron-overlay-behavior`.
