### PR TITLE
separate firefox tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ addons:
     packages:
       - google-chrome-stable
 script:
-  - xvfb-run wct
+  - xvfb-run wct -l chrome
+  - xvfb-run wct -l firefox
   - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct -s 'default'; fi"


### PR DESCRIPTION
Fixes #59 by serializing tests to be run first on chrome, then on firefox.
