### PR TITLE
use Polymer.dom().path for searching dialog-dismiss/dialog-confirm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,9 +27,10 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
     "paper-button": "PolymerElements/paper-button#^1.0.0",
     "paper-dialog-scrollable": "PolymerElements/paper-dialog-scrollable#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }

--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -168,23 +168,22 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
       this.closingReason.confirmed = confirmed;
     },
 
+    /**
+     * Will dismiss the dialog if user clicked on an element with dialog-dismiss
+     * or dialog-confirm attribute.
+     */
     _onDialogClick: function(event) {
-      var target = Polymer.dom(event).rootTarget;
-      while (target && target !== this) {
-        if (target.hasAttribute) {
-          if (target.hasAttribute('dialog-dismiss')) {
-            this._updateClosingReasonConfirmed(false);
-            this.close();
-            event.stopPropagation();
-            break;
-          } else if (target.hasAttribute('dialog-confirm')) {
-            this._updateClosingReasonConfirmed(true);
-            this.close();
-            event.stopPropagation();
-            break;
-          }
+      // Search for the element with dialog-confirm or dialog-dismiss,
+      // from the root target until this (excluded).
+      var path = Polymer.dom(event).path;
+      for (var i = 0; i < path.indexOf(this); i++) {
+        var target = path[i];
+        if (target.hasAttribute && (target.hasAttribute('dialog-dismiss') || target.hasAttribute('dialog-confirm'))) {
+          this._updateClosingReasonConfirmed(target.hasAttribute('dialog-confirm'));
+          this.close();
+          event.stopPropagation();
+          break;
         }
-        target = Polymer.dom(target).parentNode;
       }
     }
 

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -19,11 +19,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
+    <link rel="import" href="../../iron-icons/iron-icons.html">
+    <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="test-dialog.html">
     <link rel="import" href="test-buttons.html">
 
@@ -49,6 +49,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <test-dialog>
           <p>Dialog with test-buttons</p>
           <test-buttons class="buttons"></test-buttons>
+        </test-dialog>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="custom-element-button">
+      <template>
+        <test-dialog>
+          <p>Dialog</p>
+          <div class="buttons">
+            <paper-icon-button icon="cancel" dialog-dismiss></paper-icon-button>
+            <paper-icon-button icon="add-circle" dialog-confirm></paper-icon-button>
+            <paper-icon-button icon="favorite"></paper-icon-button>
+          </div>
         </test-dialog>
       </template>
     </test-fixture>
@@ -151,7 +164,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             dialog.addEventListener('iron-overlay-closed', function() {
               assert('dialog should not close');
             });
-            dialog.click();
+            MockInteractions.tap(dialog);
             setTimeout(function() {
               done();
             }, 100);
@@ -166,7 +179,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isFalse(event.detail.confirmed, 'dialog is not confirmed');
               done();
             });
-            Polymer.dom(dialog).querySelector('[dialog-dismiss]').click();
+            MockInteractions.tap(Polymer.dom(dialog).querySelector('[dialog-dismiss]'));
+          });
+        });
+
+        test('dialog-dismiss on a custom element is handled', function(done) {
+          var dialog = fixture('custom-element-button');
+          runAfterOpen(dialog, function() {
+            dialog.addEventListener('iron-overlay-closed', function(event) {
+              assert.isFalse(event.detail.canceled, 'dialog is not canceled');
+              assert.isFalse(event.detail.confirmed, 'dialog is not confirmed');
+              done();
+            });
+            MockInteractions.tap(Polymer.dom(dialog).querySelector('[dialog-dismiss]'));
           });
         });
 
@@ -178,7 +203,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isFalse(event.detail.confirmed, 'dialog is not confirmed');
               done();
             });
-            Polymer.dom(dialog).querySelector('test-buttons').$.dismiss.click();
+            MockInteractions.tap(Polymer.dom(dialog).querySelector('test-buttons').$.dismiss);
           });
         });
 
@@ -190,7 +215,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isTrue(event.detail.confirmed, 'dialog is confirmed');
               done();
             });
-            Polymer.dom(dialog).querySelector('[dialog-confirm]').click();
+            MockInteractions.tap(Polymer.dom(dialog).querySelector('[dialog-confirm]'));
+          });
+        });
+
+        test('dialog-confirm on a custom element handled', function(done) {
+          var dialog = fixture('custom-element-button');
+          runAfterOpen(dialog, function() {
+            dialog.addEventListener('iron-overlay-closed', function(event) {
+              assert.isFalse(event.detail.canceled, 'dialog is not canceled');
+              assert.isTrue(event.detail.confirmed, 'dialog is confirmed');
+              done();
+            });
+            MockInteractions.tap(Polymer.dom(dialog).querySelector('[dialog-confirm]'));
           });
         });
 
@@ -202,14 +239,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isTrue(event.detail.confirmed, 'dialog is confirmed');
               done();
             });
-            Polymer.dom(dialog).querySelector('test-buttons').$.confirm.click();
+            MockInteractions.tap(Polymer.dom(dialog).querySelector('test-buttons').$.confirm);
           });
         });
 
         test('clicking dialog-dismiss button closes only the dialog where is contained', function(done) {
           var dialog = fixture('nestedmodals');
           var innerDialog = Polymer.dom(dialog).querySelector('test-dialog');
-          Polymer.dom(innerDialog).querySelector('[dialog-dismiss]').click();
+          MockInteractions.tap(Polymer.dom(innerDialog).querySelector('[dialog-dismiss]'));
           setTimeout(function() {
             assert.isFalse(innerDialog.opened, 'inner dialog is closed');
             assert.isTrue(dialog.opened, 'dialog is still open');
@@ -220,7 +257,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('clicking dialog-confirm button closes only the dialog where is contained', function(done) {
           var dialog = fixture('nestedmodals');
           var innerDialog = Polymer.dom(dialog).querySelector('test-dialog');
-          Polymer.dom(innerDialog).querySelector('[dialog-confirm]').click();
+          MockInteractions.tap(Polymer.dom(innerDialog).querySelector('[dialog-confirm]'));
           setTimeout(function() {
             assert.isFalse(innerDialog.opened, 'inner dialog is closed');
             assert.isTrue(dialog.opened, 'dialog is still open');
@@ -274,7 +311,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('clicking outside a modal dialog does not move focus from dialog', function(done) {
           var dialog = fixture('modal');
           runAfterOpen(dialog, function() {
-            document.body.click();
+            MockInteractions.tap(document.body);
             setTimeout(function() {
               assert.equal(document.activeElement, Polymer.dom(dialog).querySelector('[autofocus]'), 'document.activeElement is the autofocused button');
               done();
@@ -291,7 +328,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               // should not throw exception here
               done();
             });
-            button.click();
+            MockInteractions.tap(button);
           });
         });
 
@@ -328,7 +365,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             dialogs[1].async(dialogs[1].open, 10);
             dialogs[1].addEventListener('iron-overlay-opened', function() {
               // This will trigger click listener for both dialogs.
-              document.body.click();
+              MockInteractions.tap(document.body);
               // Wait 10ms to allow focus changes
               setTimeout(function() {
                 // Should not enter in an infinite loop.
@@ -348,8 +385,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             dialog.removeEventListener('iron-overlay-opened', onFirstOpen);
             dialog.addEventListener('iron-overlay-closed', onFirstClose);
             // Set the focus on dismiss button
-            // Calling .focus() won't trigger the dialog._onFocus
-            Polymer.dom(dialog).querySelector('[dialog-dismiss]').dispatchEvent(new Event('focus'));
+            MockInteractions.focus(Polymer.dom(dialog).querySelector('[dialog-dismiss]'));
             // Close the dialog
             dialog.close();
           }
@@ -361,7 +397,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
 
           function onSecondOpen() {
-            document.body.click();
+            MockInteractions.tap(document.body);
             setTimeout(function() {
               assert.equal(document.activeElement, Polymer.dom(dialog).querySelector('[autofocus]'), 'document.activeElement is the autofocused button');
               done();


### PR DESCRIPTION
Fixes #66 by using `Polymer.dom(event).path` to search for `dialog-dismiss` and `dialog-confirm`.