### PR TITLE
remove non-existing methods (finish cleanup started in PR 63)

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -140,12 +140,6 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
           this.__prevNoCancelOnEscKey;
         this.withBackdrop = this.withBackdrop && this.__prevWithBackdrop;
       }
-
-      if (this.opened) {
-        // Reset focus and click listeners.
-        this._onIronOverlayClosed();
-        this._onIronOverlayOpened();
-      }
     },
 
     _updateAriaLabelledBy: function() {


### PR DESCRIPTION
Amend to https://github.com/PolymerElements/paper-dialog-behavior/pull/63 (these methods got introduced in https://github.com/PolymerElements/paper-dialog-behavior/pull/54, but https://github.com/PolymerElements/paper-dialog-behavior/pull/63 didn't rebase from master)