### PR TITLE
remove setting of aria-labelledby

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -60,8 +60,6 @@ to override this attribute with `role="alertdialog"`.
 If `modal` is set, the element will set `aria-modal` and prevent the focus from exiting the element.
 It will also ensure that focus remains in the dialog.
 
-The `aria-labelledby` attribute will be set to the header element, if one exists.
-
 @hero hero.svg
 @demo demo/index.html
 @polymerBehavior Polymer.PaperDialogBehavior
@@ -101,16 +99,6 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
       this.__prevWithBackdrop = this.withBackdrop;
     },
 
-    attached: function() {
-      // this._observer is used by iron-overlay-behavior
-      this._ariaObserver = Polymer.dom(this).observeNodes(this._updateAriaLabelledBy);
-      this._updateAriaLabelledBy();
-    },
-
-    detached: function() {
-      Polymer.dom(this).unobserveNodes(this._ariaObserver);
-    },
-
     _modalChanged: function(modal, readied) {
       if (modal) {
         this.setAttribute('aria-modal', 'true');
@@ -140,27 +128,6 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
           this.__prevNoCancelOnEscKey;
         this.withBackdrop = this.withBackdrop && this.__prevWithBackdrop;
       }
-    },
-
-    _updateAriaLabelledBy: function() {
-      var header = Polymer.dom(this).querySelector('h2');
-      if (!header) {
-        this.removeAttribute('aria-labelledby');
-        return;
-      }
-      var headerId = header.getAttribute('id');
-      if (headerId && this.getAttribute('aria-labelledby') === headerId) {
-        return;
-      }
-      // set aria-describedBy to the header element
-      var labelledById;
-      if (headerId) {
-        labelledById = headerId;
-      } else {
-        labelledById = 'paper-dialog-header-' + new Date().getUTCMilliseconds();
-        header.setAttribute('id', labelledById);
-      }
-      this.setAttribute('aria-labelledby', labelledById);
     },
 
     _updateClosingReasonConfirmed: function(confirmed) {

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -415,32 +415,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(dialog.getAttribute('aria-modal'), 'true', 'has aria-modal="true"');
         });
 
-        test('dialog with header has aria-labelledby', function() {
-          var dialog = fixture('header');
-          var header = Polymer.dom(dialog).querySelector('h2');
-          assert.ok(header.getAttribute('id'), 'header has auto-generated id');
-          assert.equal(dialog.getAttribute('aria-labelledby'), header.getAttribute('id'), 'aria-labelledby is set to header id');
-        });
-
-        test('dialog with lazily created header has aria-labelledby', function(done) {
-          var dialog = fixture('basic');
-          var header = document.createElement('h2');
-          Polymer.dom(dialog).appendChild(header);
-          Polymer.dom.flush();
-          setTimeout(function() {
-            assert.ok(header.getAttribute('id'), 'header has auto-generated id');
-            assert.equal(dialog.getAttribute('aria-labelledby'), header.getAttribute('id'), 'aria-labelledby is set to header id');
-            done();
-          }, 10);
-        });
-
-        test('dialog with header with id preserves id and has aria-labelledby', function() {
-          var dialog = fixture('header-with-id');
-          var header = Polymer.dom(dialog).querySelector('h2');
-          assert.equal(header.getAttribute('id'), 'header', 'header has preset id');
-          assert.equal(dialog.getAttribute('aria-labelledby'), 'header', 'aria-labelledby is set to header id');
-        });
-
       });
     </script>
 


### PR DESCRIPTION
Fixes #39 by not setting `aria-labelledby` to the element. 
`aria-labelledby` together with `tabindex` cause issues to readers, which will only read the `h2` content & skip the rest. The setting of `aria-labelledby` should be delegated to the user of the element.