### PR TITLE
header class for headers that are not <h2>

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -32,9 +32,18 @@ For example, if `<paper-dialog-impl>` implements this behavior:
         </div>
     </paper-dialog-impl>
 
+    <paper-dialog-impl>
+        <div class="header">My fancy header</div>
+        <paper-dialog-scrollable>
+          <div>Dialog scrollable body</div>
+        </paper-dialog-scrollable>
+    </paper-dialog-impl>
+
 `paper-dialog-shared-styles.html` provide styles for a header, content area, and an action area for buttons.
-Use the `<h2>` tag for the header and the `buttons` class for the action area. You can use the
-`paper-dialog-scrollable` element (in its own repository) if you need a scrolling content area.
+Use the `<h2>` tag for the header title or `header` class for other types of header elements,
+and the `buttons` class for the action area.
+
+You can use the `paper-dialog-scrollable` element (in its own repository) if you need a scrolling content area.
 
 Use the `dialog-dismiss` and `dialog-confirm` attributes on interactive controls to close the
 dialog. If the user dismisses the dialog with `dialog-confirm`, the `closingReason` will update

--- a/paper-dialog-common.css
+++ b/paper-dialog-common.css
@@ -21,26 +21,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   @apply(--paper-dialog);
 }
 
-:host > ::content > * {
+:host > ::content > *:not(.header):not(.buttons) {
   margin-top: 20px;
   padding: 0 24px;
 }
 
-:host > ::content > .no-padding {
-  padding: 0;
-}
-
-:host > ::content > *:first-child {
+:host > ::content > *:first-child:not(.header) {
   margin-top: 24px;
 }
 
-:host > ::content > *:last-child {
+:host > ::content > *:last-child:not(.buttons) {
   margin-bottom: 24px;
 }
 
-:host > ::content h2 {
+:host > ::content > .no-padding:not(.buttons) {
+  padding: 0;
+}
+
+:host > ::content > h2 {
   position: relative;
-  margin: 0;
   @apply(--paper-font-title);
 
   @apply(--paper-dialog-title);
@@ -49,7 +48,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host > ::content .buttons {
   position: relative;
   padding: 8px 8px 8px 24px;
-  margin: 0;
 
   color: var(--paper-dialog-button-color, --primary-color);
 

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -24,26 +24,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         @apply(--paper-dialog);
       }
 
-      :host > ::content > * {
+      :host > ::content > *:not(.header):not(.buttons) {
         margin-top: 20px;
         padding: 0 24px;
       }
 
-      :host > ::content > .no-padding {
-        padding: 0;
-      }
-
-      :host > ::content > *:first-child {
+      :host > ::content > *:first-child:not(.header) {
         margin-top: 24px;
       }
 
-      :host > ::content > *:last-child {
+      :host > ::content > *:last-child:not(.buttons) {
         margin-bottom: 24px;
       }
 
-      :host > ::content h2 {
+      :host > ::content > .no-padding:not(.buttons) {
+        padding: 0;
+      }
+
+      :host > ::content > h2 {
         position: relative;
-        margin: 0;
         @apply(--paper-font-title);
 
         @apply(--paper-dialog-title);
@@ -52,7 +51,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host > ::content .buttons {
         position: relative;
         padding: 8px 8px 8px 24px;
-        margin: 0;
 
         color: var(--paper-dialog-button-color, --primary-color);
 


### PR DESCRIPTION
Fixes #35, fixes #21 by avoiding the setting of `margin, padding` for the element with `header` class. 
Also, made styles specific enough not to be overridden by something as simple as
```html
<style is="custom-style">
  h2 {
    margin: 0;
    padding: 0;
  };
</style
```

Use case for #35: `paper-toolbar` has a background color and buttons on the left/right, and it handles padding itself, so it should use this class when used in a `paper-dialog` like this
```html
<paper-dialog>
  <paper-toolbar class="header">
    <div class="title">Header</div>
  </paper-toolbar>
  <div>Content</div>
</paper-dialog>
```