### PR TITLE
Notify when closingReason was changed

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -82,6 +82,10 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
       modal: {
         type: Boolean,
         value: false
+      },
+      closingReason: {
+        type: Object,
+        notify: true
       }
 
     },
@@ -165,7 +169,7 @@ The `aria-labelledby` attribute will be set to the header element, if one exists
 
     _updateClosingReasonConfirmed: function(confirmed) {
       this.closingReason = this.closingReason || {};
-      this.closingReason.confirmed = confirmed;
+      this.set('closingReason.confirmed', confirmed);
     },
 
     /**


### PR DESCRIPTION
Currently closingReason does not notify the parent element, making it impossible for a user to use dialog-confirm / dialog-dismiss.