### PR TITLE
Revert "make dialog scrollable so content does not overflow"

### DIFF
--- a/paper-dialog-common.css
+++ b/paper-dialog-common.css
@@ -11,11 +11,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host {
   display: block;
   margin: 24px 40px;
+  -webkit-overflow-scrolling: touch;
 
   background: var(--paper-dialog-background-color, --primary-background-color);
   color: var(--paper-dialog-color, --primary-text-color);
 
-  @apply(--layout-scroll);
   @apply(--paper-font-body1);
   @apply(--shadow-elevation-16dp);
   @apply(--paper-dialog);

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -14,11 +14,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host {
         display: block;
         margin: 24px 40px;
+        -webkit-overflow-scrolling: touch;
 
         background: var(--paper-dialog-background-color, --primary-background-color);
         color: var(--paper-dialog-color, --primary-text-color);
 
-        @apply(--layout-scroll);
         @apply(--paper-font-body1);
         @apply(--shadow-elevation-16dp);
         @apply(--paper-dialog);


### PR DESCRIPTION
Reverts PolymerElements/paper-dialog-behavior#84
Fixes #85 