### PR TITLE
remove webkit-overflow-scroll. Demo with dropdown

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,10 @@
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
     "paper-button": "PolymerElements/paper-button#^1.0.0",
     "paper-dialog-scrollable": "PolymerElements/paper-dialog-scrollable#^1.0.0",
+    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+    "paper-item": "PolymerElements/paper-item#^1.0.0",
+    "paper-listbox": "PolymerElements/paper-listbox#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,6 +22,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="simple-dialog.html">
 
   <link rel="import" href="../../paper-button/paper-button.html">
+  <link rel="import" href="../../paper-dropdown-menu/paper-dropdown-menu.html">
+  <link rel="import" href="../../paper-item/paper-item.html">
+  <link rel="import" href="../../paper-listbox/paper-listbox.html">
   <link rel="import" href="../../paper-dialog-scrollable/paper-dialog-scrollable.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
@@ -47,7 +50,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-button raised onclick="modalAlert.toggle()">modal alert</paper-button>
       <simple-dialog id="modalAlert" modal role="alertdialog">
         <h2>Alert</h2>
-        <p>Discard draft?</p>
+        <paper-dropdown-menu label="Draft to discard">
+          <paper-listbox class="dropdown-content">
+            <paper-item>Draft 1</paper-item>
+            <paper-item>Draft 2</paper-item>
+            <paper-item>Draft 3</paper-item>
+            <paper-item>Draft 4</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
         <div class="buttons">
           <paper-button onclick="modalDetails.toggle()">More details</paper-button>
           <paper-button dialog-dismiss>Cancel</paper-button>

--- a/paper-dialog-common.css
+++ b/paper-dialog-common.css
@@ -11,7 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host {
   display: block;
   margin: 24px 40px;
-  -webkit-overflow-scrolling: touch;
 
   background: var(--paper-dialog-background-color, --primary-background-color);
   color: var(--paper-dialog-color, --primary-text-color);

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host {
         display: block;
         margin: 24px 40px;
-        -webkit-overflow-scrolling: touch;
 
         background: var(--paper-dialog-background-color, --primary-background-color);
         color: var(--paper-dialog-color, --primary-text-color);


### PR DESCRIPTION
Since `paper-dialog-behavior` doesn't apply `overflow: auto` anymore, we can remove the setting of `-webkit-overflow-scrolling: touch`.
Also, added `paper-dropdown-menu` into a dialog so we can test it doesn't get clipped.