### PR TITLE
Move Styling Imports

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -10,10 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../paper-styles/default-theme.html">
-<link rel="import" href="../paper-styles/typography.html">
-<link rel="import" href="../paper-styles/shadow.html">
 
 <script>
 
@@ -39,18 +35,6 @@ Use the `<h2>` tag for the header and the `buttons` class for the action area. Y
 Use the `dialog-dismiss` and `dialog-confirm` attributes on interactive controls to close the
 dialog. If the user dismisses the dialog with `dialog-confirm`, the `closingReason` will update
 to include `confirmed: true`.
-
-### Styling
-
-The following custom properties and mixins are available for styling.
-
-Custom property | Description | Default
-----------------|-------------|----------
-`--paper-dialog-background-color` | Dialog background color                     | `--primary-background-color`
-`--paper-dialog-color`            | Dialog foreground color                     | `--primary-text-color`
-`--paper-dialog`                  | Mixin applied to the dialog                 | `{}`
-`--paper-dialog-title`            | Mixin applied to the title (`<h2>`) element | `{}`
-`--paper-dialog-button-color`     | Button area foreground color                | `--default-primary-color`
 
 ### Accessibility
 

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -8,6 +8,24 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../paper-styles/shadow.html">
+
+/**
+### Styling
+The following custom properties and mixins are available for styling.
+Custom property | Description | Default
+----------------|-------------|----------
+`--paper-dialog-background-color` | Dialog background color                     | `--primary-background-color`
+`--paper-dialog-color`            | Dialog foreground color                     | `--primary-text-color`
+`--paper-dialog`                  | Mixin applied to the dialog                 | `{}`
+`--paper-dialog-title`            | Mixin applied to the title (`<h2>`) element | `{}`
+`--paper-dialog-button-color`     | Button area foreground color                | `--default-primary-color`
+*/
+
 <dom-module id="paper-dialog-shared-styles">
   <template>
     <style>

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -16,7 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <!--
 ### Styling
+
 The following custom properties and mixins are available for styling.
+
 Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-dialog-background-color` | Dialog background color                     | `--primary-background-color`

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../paper-styles/shadow.html">
 
-/**
+<!--
 ### Styling
 The following custom properties and mixins are available for styling.
 Custom property | Description | Default
@@ -24,7 +24,7 @@ Custom property | Description | Default
 `--paper-dialog`                  | Mixin applied to the dialog                 | `{}`
 `--paper-dialog-title`            | Mixin applied to the title (`<h2>`) element | `{}`
 `--paper-dialog-button-color`     | Button area foreground color                | `--default-primary-color`
-*/
+-->
 
 <dom-module id="paper-dialog-shared-styles">
   <template>


### PR DESCRIPTION
I've moved the imports bringing Flex Layout and Paper Styling into the world of dialogs from the functional behavior to the shared styles that you can opt into using, or not. This should simplify the dependency tree for behavior users and clarify the origin of those dependencies for users of the shared styles.

I moved the inline documentation for application of CSS variable from the behavior to the shared styles as well, but didn't remove them from Readme.md. They seemed useful there. I'm unsure if further clarification is needed therein as to how to ensure the availability of that style interface. 


References #91 