### PR TITLE
dialog-dismiss should cancel() rather than close()

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -129,9 +129,22 @@ It will also ensure that focus remains in the dialog.
       var path = Polymer.dom(event).path;
       for (var i = 0; i < path.indexOf(this); i++) {
         var target = path[i];
-        if (target.hasAttribute && (target.hasAttribute('dialog-dismiss') || target.hasAttribute('dialog-confirm'))) {
-          this._updateClosingReasonConfirmed(target.hasAttribute('dialog-confirm'));
-          this.close();
+        if (!target.hasAttribute) {
+          continue;
+        }
+        
+        var hasConfirm = target.hasAttribute('dialog-confirm');
+        var hasDismiss = target.hasAttribute('dialog-dismiss');
+        
+        if (hasConfirm || hasDismiss) {
+          this._updateClosingReasonConfirmed(hasConfirm);
+          
+          if (hasDismiss) {
+            this.cancel();
+          } else {
+            this.close();
+          }
+          
           event.stopPropagation();
           break;
         }


### PR DESCRIPTION
so I saw a whole bunch of asserts in the tests regarding `event.detail.canceled` being `false` if `dialog-dismiss` is tapped.  is that intentional or just boiler-platey?

anyways, what do you think of this @valdrinkoshi and @notwaldorf?  if you agree, I'll update the tests.