### PR TITLE
remove aria-modal

### DIFF
--- a/paper-dialog-behavior.html
+++ b/paper-dialog-behavior.html
@@ -41,7 +41,7 @@ to include `confirmed: true`.
 This element has `role="dialog"` by default. Depending on the context, it may be more appropriate
 to override this attribute with `role="alertdialog"`.
 
-If `modal` is set, the element will set `aria-modal` and prevent the focus from exiting the element.
+If `modal` is set, the element will prevent the focus from exiting the element.
 It will also ensure that focus remains in the dialog.
 
 @hero hero.svg
@@ -84,12 +84,6 @@ It will also ensure that focus remains in the dialog.
     },
 
     _modalChanged: function(modal, readied) {
-      if (modal) {
-        this.setAttribute('aria-modal', 'true');
-      } else {
-        this.setAttribute('aria-modal', 'false');
-      }
-
       // modal implies noCancelOnOutsideClick, noCancelOnEscKey and withBackdrop.
       // We need to wait for the element to be ready before we can read the
       // properties values.

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -400,16 +400,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(dialog.getAttribute('role'), 'dialog', 'has role="dialog"');
         });
 
-        test('dialog has aria-modal=false', function() {
-          var dialog = fixture('basic');
-          assert.equal(dialog.getAttribute('aria-modal'), 'false', 'has aria-modal="false"');
-        });
-
-        test('modal dialog has aria-modal=true', function() {
-          var dialog = fixture('modal');
-          assert.equal(dialog.getAttribute('aria-modal'), 'true', 'has aria-modal="true"');
-        });
-
       });
     </script>
 


### PR DESCRIPTION
Fixes #95 by removing the setting of `aria-modal` attribute.
This was originally added in #4, but it doesn't seem to be a valid attribute https://www.w3.org/TR/wai-aria/states_and_properties#state_prop_def