### PR TITLE
handle margin in --paper-dialog-title

### DIFF
--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -52,9 +52,18 @@ Custom property | Description | Default
         padding: 0;
       }
 
+      
+      :host > ::slotted(*:first-child) {
+        margin-top: 24px;
+      }
+
+      :host > ::slotted(*:last-child) {
+        margin-bottom: 24px;
+      }
+
       /* In 1.x, this selector was `:host > ::content h2`. In 2.x <slot> allows
-      to select direct children only, which increases the weight of this
-      selector, so we have to move it before first-child/last-child selectors */
+      to only select only direct children, which increases the weight of this
+      selector, so we have to re-define first-child/last-child margins below. */
       :host > ::slotted(h2) {
         position: relative;
         margin: 0;
@@ -63,12 +72,16 @@ Custom property | Description | Default
         @apply --paper-dialog-title;
       }
 
-      :host > ::slotted(*:first-child) {
+      /* Apply mixin again, in case it sets margin-top. */
+      :host > ::slotted(h2:first-child) {
         margin-top: 24px;
+        @apply --paper-dialog-title;
       }
 
-      :host > ::slotted(*:last-child) {
+      /* Apply mixin again, in case it sets margin-bottom. */
+      :host > ::slotted(h2:last-child) {
         margin-bottom: 24px;
+        @apply --paper-dialog-title;
       }
 
       :host > ::slotted(.buttons) {

--- a/paper-dialog-shared-styles.html
+++ b/paper-dialog-shared-styles.html
@@ -62,7 +62,7 @@ Custom property | Description | Default
       }
 
       /* In 1.x, this selector was `:host > ::content h2`. In 2.x <slot> allows
-      to only select only direct children, which increases the weight of this
+      to select direct children only, which increases the weight of this
       selector, so we have to re-define first-child/last-child margins below. */
       :host > ::slotted(h2) {
         position: relative;

--- a/test/paper-dialog-behavior.html
+++ b/test/paper-dialog-behavior.html
@@ -31,6 +31,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <body>
 
+    <custom-style><style is="custom-style">
+      .no-margin-title {
+        --paper-dialog-title: {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+      }
+    </style></custom-style>
+
     <test-fixture id="basic">
       <template>
         <test-dialog>
@@ -89,23 +98,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <test-fixture id="header">
       <template>
         <test-dialog>
-          <h2>Dialog</h2>
-          <div class="buttons">
-            <button dialog-dismiss>dismiss</button>
-            <button dialog-confirm autofocus>confirm</button>
-          </div>
+          <h2>1st</h2>
+          <h2>2nd</h2>
+          <h2>3rd</h2>
         </test-dialog>
-      </template>
-    </test-fixture>
-
-    <test-fixture id="header-with-id">
-      <template>
-        <test-dialog>
-          <h2 id="header">Dialog</h2>
-          <div class="buttons">
-            <button dialog-dismiss>dismiss</button>
-            <button dialog-confirm autofocus>confirm</button>
-          </div>
+        <test-dialog class="no-margin-title">
+          <h2>1st</h2>
+          <h2>2nd</h2>
+          <h2>3rd</h2>
         </test-dialog>
       </template>
     </test-fixture>
@@ -393,6 +393,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         });
 
+      });
+
+      suite('style', function() {
+
+        test('apply margin to <h2>', function() {
+          var dialog = fixture('header')[0];
+          var h2s = dialog.querySelectorAll('h2');
+          assert.equal(getComputedStyle(h2s[0]).marginTop, '24px', '1st margin-top');
+          assert.equal(getComputedStyle(h2s[1]).marginTop, '0px', '2nd margin-top');
+          assert.equal(getComputedStyle(h2s[1]).marginBottom, '0px', '2nd margin-bottom');
+          assert.equal(getComputedStyle(h2s[2]).marginBottom, '24px', '3rd margin-bottom');
+        });
+
+        test('applies --paper-dialog-title mixin', function() {
+          var dialog = fixture('header')[1];
+          var h2s = dialog.querySelectorAll('h2');
+          assert.equal(getComputedStyle(h2s[0]).marginTop, '0px', '1st margin-top');
+          assert.equal(getComputedStyle(h2s[1]).marginTop, '0px', '2nd margin-top');
+          assert.equal(getComputedStyle(h2s[1]).marginBottom, '0px', '2nd margin-bottom');
+          assert.equal(getComputedStyle(h2s[2]).marginBottom, '0px', '3rd margin-bottom');
+        });
       });
 
       suite('a11y', function() {


### PR DESCRIPTION
Fixes #118 by re-applying the mixin for `h2` so that `margin-top` and `margin-bottom` can be overridden via the mixin.
Here the repro showed in #118 with this fix applied https://jsbin.com/pitiqag/1/edit?html,output

Note that this doesn't fix the case where the mixin sets `margin`, e.g.
```css
#dialog {
  --paper-dialog-title: {
    margin: 0
  }
}
```